### PR TITLE
fix: update timeout to avoid concurrency and clean workflow

### DIFF
--- a/.github/workflows/deploy-smart.yaml
+++ b/.github/workflows/deploy-smart.yaml
@@ -27,19 +27,8 @@ jobs:
         run: |
           cd ./fwoa-utilities/javaHapiValidatorLambda
           mvn --batch-mode --update-snapshots --no-transfer-progress clean install
-  pre-deployment-check:
-    needs: build-validate
-    runs-on: ubuntu-20.04
-    timeout-minutes: 10
-    steps:
-      - name: 'Block Concurrent Deployments'
-        uses: softprops/turnstyle@v1
-        with:
-          poll-interval-seconds: 10
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   deploy:
-    needs: pre-deployment-check
+    needs: build-validate
     name: Deploy to Dev - enableMultiTenancy=${{ matrix.enableMultiTenancy }}
     environment: FWoA Integ Test Env
     runs-on: ubuntu-20.04

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,19 +34,8 @@ jobs:
         run: |
           cd ./fwoa-utilities/javaHapiValidatorLambda
           mvn --batch-mode --update-snapshots --no-transfer-progress clean install
-  pre-deployment-check:
-    needs: build-validate
-    runs-on: ubuntu-20.04
-    timeout-minutes: 10
-    steps:
-      - name: 'Block Concurrent Deployments'
-        uses: softprops/turnstyle@v1
-        with:
-          poll-interval-seconds: 10
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   deploy:
-    needs: pre-deployment-check
+    needs: build-validate
     name: Deploy to Dev - enableMultiTenancy=${{ matrix.enableMultiTenancy }}
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/merge-develop-to-stage.yml
+++ b/.github/workflows/merge-develop-to-stage.yml
@@ -13,7 +13,7 @@ jobs:
   pre-deployment-check:
     name: Pre deployment check
     runs-on: ubuntu-20.04
-    timeout-minutes: 40
+    timeout-minutes: 120
     steps:
       - name: Use Node.js 18.x
         uses: actions/setup-node@v3


### PR DESCRIPTION
Issue #, if available:

Description of changes:
set timeout time before next concurrent workflow to 120 mins and clean pre deployment checks for deploy.yml and deploy-smart.yml
Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Did you add new integration tests?
- [ ] Did you run integration tests with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
