### PR TITLE
refactor: upgrade runner credentials

### DIFF
--- a/.github/workflows/deploy-smart.yaml
+++ b/.github/workflows/deploy-smart.yaml
@@ -2,10 +2,6 @@ name: (SMART) Unit Tests, Deploy, Integration Test
 on:
   workflow_call:
 
-env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.SMART_AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.SMART_AWS_SECRET_ACCESS_KEY }}
-
 jobs:
   build-validate:
     name: Build and validate
@@ -45,12 +41,22 @@ jobs:
             issuerEndpointSecretName: MULTITENANCY_SMART_ISSUER_ENDPOINT
             oAuth2ApiEndpointSecretName: MULTITENANCY_SMART_OAUTH2_API_ENDPOINT
             patientPickerEndpointSecretName: MULTITENANCY_SMART_PATIENT_PICKER_ENDPOINT
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: ${{ matrix.region }}
+          role-to-assume: ${{ secrets.AWS_ACCESS_ROLE_ARN }}
+          role-duration-seconds: 7200
       - name: Base Action
         uses: ./.github/actions/baseAction
 
@@ -97,6 +103,9 @@ jobs:
             region: us-east-2
             serviceUrlSuffix: /tenant/tenant1
             smartServiceURLSecretName: MULTITENANCY_SMART_SERVICE_URL
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v3
         with:
@@ -105,6 +114,12 @@ jobs:
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: '2.6'
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: ${{ matrix.region }}
+          role-to-assume: ${{ secrets.AWS_ACCESS_ROLE_ARN }}
+          role-duration-seconds: 7200
       - name: Install dependency
         run: |
           gem install bundler
@@ -161,9 +176,18 @@ jobs:
             subscriptionsNotificationsTableSecretName: MULTITENANCY_SMART_SUBSCRIPTIONS_NOTIFICATIONS_TABLE
             subscriptionsEndpointSecretName: MULTITENANCY_SMART_SUBSCRIPTIONS_ENDPOINT
             subscriptionsApiKeySecretName: MULTITENANCY_SMART_SUBSCRIPTIONS_API_KEY
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: ${{ matrix.region }}
+          role-to-assume: ${{ secrets.AWS_ACCESS_ROLE_ARN }}
+          role-duration-seconds: 7200
       - name: Base Action
         uses: ./.github/actions/baseAction
       - name: Execute tests

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,10 +7,6 @@ name: Unit Tests, Deploy, Integration Test
 on:
   workflow_call:
 
-env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
 jobs:
   build-validate:
     name: Build and validate
@@ -45,6 +41,10 @@ jobs:
             region: us-west-1
           - enableMultiTenancy: true
             region: us-west-2
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -52,6 +52,13 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 1.8
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: ${{ matrix.region }}
+          role-to-assume: ${{ secrets.AWS_ACCESS_ROLE_ARN }}
+          role-duration-seconds: 7200
 
       - name: Base Action
         uses: ./.github/actions/baseAction
@@ -108,6 +115,9 @@ jobs:
             serviceUrlSecretName: MULTITENANCY_SERVICE_URL
             cognitoClientIdSecretName: MULTITENANCY_COGNITO_CLIENT_ID
             apiKeySecretName: MULTITENANCY_API_KEY
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v3
         with:
@@ -116,6 +126,12 @@ jobs:
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: '2.6'
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: ${{ matrix.region }}
+          role-to-assume: ${{ secrets.AWS_ACCESS_ROLE_ARN }}
+          role-duration-seconds: 7200
       - name: Install dependency
         run: |
           gem install bundler
@@ -156,9 +172,19 @@ jobs:
             subscriptionsNotificationsTableSecretName: MULTITENANCY_SUBSCRIPTIONS_NOTIFICATIONS_TABLE
             subscriptionsEndpointSecretName: MULTITENANCY_SUBSCRIPTIONS_ENDPOINT
             subscriptionsApiKeySecretName: MULTITENANCY_SUBSCRIPTIONS_API_KEY
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: ${{ matrix.region }}
+          role-to-assume: ${{ secrets.AWS_ACCESS_ROLE_ARN }}
+          role-duration-seconds: 7200
 
       - name: Base Action
         uses: ./.github/actions/baseAction


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Upgraded runners to no longer use `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` directly, but rather fetch them using aws-actions/configure-aws-credentials GitHub Action and an assumed STS Role. This secret has been added to the repository. This also leverages GitHub OIDC connection to establish trust.

Tested by using nektos/act to run the workflow locally. Unfortunately, because of the trust relationship between GitHub and the STS role, i was unable to test the action directly as it wasn't running on GitHub. I instead created temporary credentials with the same permission set, and used those to run integ-tests and verified that they passed.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [X] Did you run integration tests with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
