### PR TITLE
chore: add object ownership to S3 buckets

### DIFF
--- a/solutions/deployment/lib/bulkExport.ts
+++ b/solutions/deployment/lib/bulkExport.ts
@@ -12,7 +12,7 @@ import {
     StarPrincipal,
 } from 'aws-cdk-lib/aws-iam';
 import { Key } from 'aws-cdk-lib/aws-kms';
-import { Bucket, BucketEncryption } from 'aws-cdk-lib/aws-s3';
+import { Bucket, BucketEncryption, ObjectOwnership } from 'aws-cdk-lib/aws-s3';
 import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
 
@@ -110,6 +110,7 @@ export default class BulkExportResources {
             blockPublicAccess,
             enforceSSL: true,
             versioned: true,
+            objectOwnership: ObjectOwnership.OBJECT_WRITER
         });
 
         NagSuppressions.addResourceSuppressions(this.glueScriptsBucket, [
@@ -138,6 +139,7 @@ export default class BulkExportResources {
             blockPublicAccess,
             versioned: true,
             enforceSSL: true,
+            objectOwnership: ObjectOwnership.OBJECT_WRITER
         });
         NagSuppressions.addResourceSuppressions(this.bulkExportResultsBucket, [
             {

--- a/solutions/deployment/lib/cdk-infra-stack.ts
+++ b/solutions/deployment/lib/cdk-infra-stack.ts
@@ -34,7 +34,7 @@ import {
 import { Alias } from 'aws-cdk-lib/aws-kms';
 import { Runtime, StartingPosition, Tracing } from 'aws-cdk-lib/aws-lambda';
 import { DynamoEventSource, SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
-import { Bucket, BucketAccessControl, BucketEncryption } from 'aws-cdk-lib/aws-s3';
+import { Bucket, BucketAccessControl, BucketEncryption, ObjectOwnership } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 import { Queue, QueuePolicy } from 'aws-cdk-lib/aws-sqs';
 import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
@@ -133,6 +133,7 @@ export default class FhirWorksStack extends Stack {
       },
       versioned: true,
       enforceSSL: true,
+      objectOwnership: ObjectOwnership.OBJECT_WRITER
     });
     NagSuppressions.addResourceSuppressions(fhirLogsBucket, [
       {
@@ -266,7 +267,8 @@ export default class FhirWorksStack extends Stack {
         blockPublicPolicy: true,
         ignorePublicAcls: true,
         restrictPublicBuckets: true
-      }
+      },
+      objectOwnership: ObjectOwnership.OBJECT_WRITER
     });
 
     fhirBinaryBucket.addToResourcePolicy(

--- a/solutions/deployment/lib/javaHapiValidator.ts
+++ b/solutions/deployment/lib/javaHapiValidator.ts
@@ -4,7 +4,7 @@ import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import { BucketDeployment, Source } from 'aws-cdk-lib/aws-s3-deployment';
 import * as path from 'path';
-import { Bucket, BucketAccessControl, BucketEncryption } from 'aws-cdk-lib/aws-s3';
+import { Bucket, BucketAccessControl, BucketEncryption, ObjectOwnership } from 'aws-cdk-lib/aws-s3';
 import { Key } from 'aws-cdk-lib/aws-kms';
 
 export interface JavaHapiValidatorProps extends StackProps {
@@ -40,6 +40,7 @@ export default class JavaHapiValidator extends Stack {
             enforceSSL: true,
             versioned: true,
             encryptionKey: props.s3KMSKey,
+            objectOwnership: ObjectOwnership.OBJECT_WRITER
         });
         const igDeployment = new BucketDeployment(scope, `IGDeployment-${props.stage}`, {
             sources: [Source.asset(path.resolve(__dirname, '../implementationGuides'))],


### PR DESCRIPTION
Issue #, if available:

Description of changes:
NIghtwatch test failing if objectOwnership property is not set on an S3 Bucket in CDK. This adds the property to all S3 buckets.
Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Did you add new integration tests?
- [ ] Did you run integration tests with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
