### PR TITLE
chore: Add environment to gh workflows

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,7 @@ Checklist:
 - [ ] Did you add new integration tests?
 - [ ] Did you run integration tests with your changes?
 
+Instructions for Reviewers:
+Your review is required for workflows to be executed. To approve a workflow, scroll down to checks and on each check click on details -> Review pending deployments -> Approve and deploy. The owner of this PR can also approve workflows AFTER you have approved this PR.
+
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,7 @@ Checklist:
 - [ ] Did you run integration tests with your changes?
 
 Instructions for Reviewers:
+
 Your review is required for workflows to be executed. To approve a workflow, scroll down to checks and on each check click on details -> Review pending deployments -> Approve and deploy. The owner of this PR can also approve workflows AFTER you have approved this PR.
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -13,6 +13,7 @@ jobs:
   main-protection:
     name: Only create PR against develop branch, not main or stage branch
     runs-on: ubuntu-20.04
+    environment: FWoA Checks
     steps:
       - name: Use Node.js 18.x
         uses: actions/setup-node@v3

--- a/.github/workflows/build-test-coverage.yml
+++ b/.github/workflows/build-test-coverage.yml
@@ -9,6 +9,7 @@ on: ['pull_request']
 jobs:
   build-test-coverage:
     runs-on: ubuntu-20.04
+    environment: FWoA Checks
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/cfn-analysis.yml
+++ b/.github/workflows/cfn-analysis.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   cfn-analyze:
     runs-on: ubuntu-latest
+    environment: FWoA Checks
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   CodeQL-Analyze:
     runs-on: ubuntu-latest
-
+    environment: FWoA Checks
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       source_branch: ${{ steps.create_branch.outputs.source_branch }}
+    environment: FWoA Checks
     steps:
       - uses: actions-cool/check-user-permission@v2
         with:
@@ -44,6 +45,7 @@ jobs:
     needs: create-release-branch
     outputs:
       pr_number: ${{ steps.open-pr.outputs.pr_number }}
+    environment: FWoA Checks
     steps:
     - name: Get current date
       id: date
@@ -69,6 +71,7 @@ jobs:
   merge-release-pr-to-main:
     runs-on: ubuntu-20.04
     needs: create-release-branch-pr-to-main
+    environment: FWoA Checks
     steps:
       - name: enable merge commits
         uses: octokit/request-action@v2.x

--- a/.github/workflows/deploy-smart.yaml
+++ b/.github/workflows/deploy-smart.yaml
@@ -6,6 +6,7 @@ jobs:
   build-validate:
     name: Build and validate
     runs-on: ubuntu-20.04
+    environment: FWoA Checks
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -106,6 +107,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    environment: FWoA Checks
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,6 +11,7 @@ jobs:
   build-validate:
     name: Build and validate
     runs-on: ubuntu-20.04
+    environment: FWoA Checks
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -45,6 +46,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    environment: FWoA Checks
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -118,6 +120,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    environment: FWoA Checks
     steps:
       - uses: actions/checkout@v3
         with:
@@ -175,6 +178,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    environment: FWoA Checks
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,7 @@ jobs:
   labeler:
     runs-on: ubuntu-latest
     name: Label the PR size
+    environment: FWoA Checks
     steps:
       - uses: codelytv/pr-size-labeler@v1
         with:

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -8,6 +8,7 @@ jobs:
   lint-pr:
     name: Validate PR title
     runs-on: ubuntu-20.04
+    environment: FWoA Checks
     steps:
       - uses: amannn/action-semantic-pull-request@v4
         env:

--- a/.github/workflows/merge-develop-to-stage.yml
+++ b/.github/workflows/merge-develop-to-stage.yml
@@ -14,6 +14,7 @@ jobs:
     name: Pre deployment check
     runs-on: ubuntu-20.04
     timeout-minutes: 120
+    environment: FWoA Checks
     steps:
       - name: Use Node.js 18.x
         uses: actions/setup-node@v3
@@ -40,6 +41,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [deploy-fhir, deploy-smart-fhir]
     if: ${{ (needs.deploy-fhir.result=='success') && (needs.deploy-smart-fhir.result=='success') }}
+    environment: FWoA Checks
     steps:    
       - uses: actions/checkout@v3
         with:
@@ -104,6 +106,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [deploy-fhir, deploy-smart-fhir]
     if: failure()
+    environment: FWoA Checks
     steps:
       - name: Slack notification when tests in deployment or smart-deployment failed
         id: slack

--- a/.github/workflows/no-response.yaml
+++ b/.github/workflows/no-response.yaml
@@ -17,6 +17,7 @@ on:
 jobs:
   noResponse:
     runs-on: ubuntu-latest
+    environment: FWoA Checks
     steps:
       - uses: lee-dohm/no-response@v0.5.0
         with:

--- a/.github/workflows/pnpm-audit-periodically-with-notification.yml
+++ b/.github/workflows/pnpm-audit-periodically-with-notification.yml
@@ -15,6 +15,7 @@ jobs:
     needs: pnpm-audit-work
     runs-on: ubuntu-20.04
     if: failure()
+    environment: FWoA Checks
     steps:
       - name: Slack notification when pnpm-audit-work fails
         id: slack

--- a/.github/workflows/pnpm-audit-pr.yml
+++ b/.github/workflows/pnpm-audit-pr.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   pnpm-audit:
     runs-on: ubuntu-20.04
+    environment: FWoA Checks
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/publish-and-merge-to-develop.yml
+++ b/.github/workflows/publish-and-merge-to-develop.yml
@@ -10,6 +10,7 @@ jobs:
   rush-publish:
     if: github.event.pull_request.merged == true && vars.PUBLISH_TO_NPM == 'true'
     runs-on: ubuntu-20.04
+    environment: FWoA Checks
     steps:
       - name: git checkout
         uses: actions/checkout@v3
@@ -36,6 +37,7 @@ jobs:
     name: Merge main to develop
     runs-on: ubuntu-20.04
     needs: [rush-publish]
+    environment: FWoA Checks
     steps:    
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/smart-integ-inferno-test-periodically.yaml
+++ b/.github/workflows/smart-integ-inferno-test-periodically.yaml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: '0 13 1,15 * *'
 
+env:
+  AWS_ACCESS_KEY_ID: ${{ secrets.SMART_AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.SMART_AWS_SECRET_ACCESS_KEY }}
+
 jobs:
   inferno-test:
     name: Run Inferno Tests - enableMultiTenancy=${{ matrix.enableMultiTenancy }}
@@ -19,9 +23,7 @@ jobs:
             region: us-east-2
             serviceUrlSuffix: /tenant/tenant1
             smartServiceURLSecretName: MULTITENANCY_SMART_SERVICE_URL
-    permissions:
-      id-token: write
-      contents: read
+    environment: FWoA Checks
     steps:
       - uses: actions/checkout@v3
         with:
@@ -30,12 +32,6 @@ jobs:
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: '2.6'
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-region: ${{ matrix.region }}
-          role-to-assume: ${{ secrets.AWS_ACCESS_ROLE_ARN }}
-          role-duration-seconds: 7200
       - name: Install dependency
         run: |
           gem install bundler
@@ -67,7 +63,7 @@ jobs:
   custom-integration-tests:
     needs: inferno-test
     name: Run custom integration tests - enableMultiTenancy=${{ matrix.enableMultiTenancy }}
-    environment: FWoA Integ Test Env
+    environment: FWoA Checks
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -92,18 +88,9 @@ jobs:
             subscriptionsNotificationsTableSecretName: MULTITENANCY_SMART_SUBSCRIPTIONS_NOTIFICATIONS_TABLE
             subscriptionsEndpointSecretName: MULTITENANCY_SMART_SUBSCRIPTIONS_ENDPOINT
             subscriptionsApiKeySecretName: MULTITENANCY_SMART_SUBSCRIPTIONS_API_KEY
-    permissions:
-      id-token: write
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-region: ${{ matrix.region }}
-          role-to-assume: ${{ secrets.AWS_ACCESS_ROLE_ARN }}
-          role-duration-seconds: 7200
       - name: Base Action
         uses: ./.github/actions/baseAction
       - name: Execute tests
@@ -127,21 +114,3 @@ jobs:
         run: |
           cd ./solutions/smart-deployment
           node ../../common/scripts/install-run-rushx.js int-test
-  slack-notification:
-    needs: [inferno-test, custom-integration-tests]
-    runs-on: ubuntu-20.04
-    if: failure()
-    steps:
-      - name: Slack notification when inferno tests or integration tests failed
-        id: slack
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          payload: |
-            {
-              "slack_message": "On ${{ github.ref_name }} branch of ${{ github.repository }}:",
-              "inferno_result": "${{ needs.inferno-test.result }}",
-              "integration_result": "${{ needs.custom-integration-tests.result }}",
-              "workflow_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SCHEDULED_INTEGRATION_WEBHOOK_URL }}

--- a/.github/workflows/smart-integ-inferno-test-periodically.yaml
+++ b/.github/workflows/smart-integ-inferno-test-periodically.yaml
@@ -3,10 +3,6 @@ on:
   schedule:
     - cron: '0 13 1,15 * *'
 
-env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.SMART_AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.SMART_AWS_SECRET_ACCESS_KEY }}
-
 jobs:
   inferno-test:
     name: Run Inferno Tests - enableMultiTenancy=${{ matrix.enableMultiTenancy }}
@@ -23,6 +19,9 @@ jobs:
             region: us-east-2
             serviceUrlSuffix: /tenant/tenant1
             smartServiceURLSecretName: MULTITENANCY_SMART_SERVICE_URL
+    permissions:
+      id-token: write
+      contents: read
     environment: FWoA Checks
     steps:
       - uses: actions/checkout@v3
@@ -32,6 +31,12 @@ jobs:
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: '2.6'
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: ${{ matrix.region }}
+          role-to-assume: ${{ secrets.AWS_ACCESS_ROLE_ARN }}
+          role-duration-seconds: 7200
       - name: Install dependency
         run: |
           gem install bundler
@@ -88,9 +93,18 @@ jobs:
             subscriptionsNotificationsTableSecretName: MULTITENANCY_SMART_SUBSCRIPTIONS_NOTIFICATIONS_TABLE
             subscriptionsEndpointSecretName: MULTITENANCY_SMART_SUBSCRIPTIONS_ENDPOINT
             subscriptionsApiKeySecretName: MULTITENANCY_SMART_SUBSCRIPTIONS_API_KEY
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: ${{ matrix.region }}
+          role-to-assume: ${{ secrets.AWS_ACCESS_ROLE_ARN }}
+          role-duration-seconds: 7200
       - name: Base Action
         uses: ./.github/actions/baseAction
       - name: Execute tests
@@ -114,3 +128,22 @@ jobs:
         run: |
           cd ./solutions/smart-deployment
           node ../../common/scripts/install-run-rushx.js int-test
+  slack-notification:
+    needs: [inferno-test, custom-integration-tests]
+    runs-on: ubuntu-20.04
+    if: failure()
+    environment: FWoA Checks
+    steps:
+      - name: Slack notification when inferno tests or integration tests failed
+        id: slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "slack_message": "On ${{ github.ref_name }} branch of ${{ github.repository }}:",
+              "inferno_result": "${{ needs.inferno-test.result }}",
+              "integration_result": "${{ needs.custom-integration-tests.result }}",
+              "workflow_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SCHEDULED_INTEGRATION_WEBHOOK_URL }}

--- a/.github/workflows/solutions-pipeline.yml
+++ b/.github/workflows/solutions-pipeline.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+    environment: FWoA Checks
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/solutions-pull-request.yml
+++ b/.github/workflows/solutions-pull-request.yml
@@ -8,6 +8,7 @@ jobs:
   pull-request-job:
     name: Viperlight Scan
     runs-on: ubuntu-latest
+    environment: FWoA Checks
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/verify-changes.yml
+++ b/.github/workflows/verify-changes.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   run-rush-change-verify:
     runs-on: ubuntu-20.04
+    environment: FWoA Checks
     steps:
       - name: Use Node.js 18.x
         uses: actions/setup-node@v3


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Add environments to workflows so that we can require reviewers before actions are run.
To review a workflow from a PR, scroll down to checks and on each check click on details -> Review pending deployments -> Approve and deploy

The owner of the PR is only allowed to approve workflows AFTER the code review has been approved by a member of the team. Otherwise, only other team members can approve a workflow.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Did you add new integration tests?
- [ ] Did you run integration tests with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
