### PR TITLE
fix: migration import multi tenant fix

### DIFF
--- a/fwoa-tools/src/migrationImport.ts
+++ b/fwoa-tools/src/migrationImport.ts
@@ -175,7 +175,6 @@ async function checkFolderSizeOfResource(resources: string[]): Promise<void> {
           ContinuationToken: continuationToken
         })
         .promise();
-      console.log('response', response);
       if (response.Contents) {
         response.Contents.forEach((item) => {
           if (item.Size) {
@@ -295,7 +294,7 @@ async function checkConfiguration(): Promise<void> {
   logs.write(`${new Date().toISOString()}: Finished checking configuration\n`);
 }
 (async () => {
-  await checkConfiguration();
+  // await checkConfiguration();
   await checkConvertedBinaryFileSize();
   await checkFolderSizeOfResource(Object.keys(outputFile.file_names));
   if (!dryRun) {

--- a/fwoa-tools/src/migrationImport.ts
+++ b/fwoa-tools/src/migrationImport.ts
@@ -167,11 +167,14 @@ async function checkFolderSizeOfResource(resources: string[]): Promise<void> {
 
     let folderSize = 0;
     let continuationToken: string | undefined = undefined;
+    const prefix = MIGRATION_TENANT_ID
+      ? `${MIGRATION_TENANT_ID}/${outputFile.jobId}/${resource}`
+      : `${outputFile.jobId}/${resource}`;
     do {
       const response: ListObjectsV2Output = await s3Client
         .listObjectsV2({
           Bucket: IMPORT_OUTPUT_S3_BUCKET_NAME!,
-          Prefix: `${MIGRATION_TENANT_ID!}/${outputFile.jobId}/${resource}`,
+          Prefix: prefix,
           ContinuationToken: continuationToken
         })
         .promise();
@@ -206,11 +209,14 @@ async function checkConvertedBinaryFileSize(): Promise<void> {
   const maximumBinaryFileSize = 5368709120; // 5 GB in bytes
   const convertedBinaryFolderName = 'Binary_converted';
   let continuationToken: string | undefined = undefined;
+  const prefix = MIGRATION_TENANT_ID
+    ? `${MIGRATION_TENANT_ID}/${outputFile.jobId}/${convertedBinaryFolderName}`
+    : `${outputFile.jobId}/${convertedBinaryFolderName}`;
   do {
     const response: ListObjectsV2Output = await s3Client
       .listObjectsV2({
         Bucket: IMPORT_OUTPUT_S3_BUCKET_NAME!,
-        Prefix: `${MIGRATION_TENANT_ID}/${outputFile.jobId}/${convertedBinaryFolderName}`,
+        Prefix: prefix,
         ContinuationToken: continuationToken
       })
       .promise();
@@ -294,7 +300,7 @@ async function checkConfiguration(): Promise<void> {
   logs.write(`${new Date().toISOString()}: Finished checking configuration\n`);
 }
 (async () => {
-  // await checkConfiguration();
+  await checkConfiguration();
   await checkConvertedBinaryFileSize();
   await checkFolderSizeOfResource(Object.keys(outputFile.file_names));
   if (!dryRun) {

--- a/fwoa-tools/src/migrationImport.ts
+++ b/fwoa-tools/src/migrationImport.ts
@@ -295,8 +295,8 @@ async function checkConfiguration(): Promise<void> {
   logs.write(`${new Date().toISOString()}: Finished checking configuration\n`);
 }
 (async () => {
-  // await checkConfiguration();
-  // await checkConvertedBinaryFileSize();
+  await checkConfiguration();
+  await checkConvertedBinaryFileSize();
   await checkFolderSizeOfResource(Object.keys(outputFile.file_names));
   if (!dryRun) {
     try {


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Exported files are prefixed with tenantId so file size check script should look for files in the correct S3 folder. 

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Did you add new integration tests?
- [ ] Did you run integration tests with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
