### PR TITLE
fix: add extended polling time on import

### DIFF
--- a/fwoa-tools/src/migrationImport.ts
+++ b/fwoa-tools/src/migrationImport.ts
@@ -20,7 +20,8 @@ import {
   checkConfiguration,
   HEALTHLAKE_BUNDLE_LIMIT,
   Bundle,
-  getEmptyFHIRBundle
+  getEmptyFHIRBundle,
+  EXTENDED_POLLING_TIME
 } from './migrationUtils';
 
 dotenv.config({ path: '.env' });
@@ -135,7 +136,7 @@ export async function startImport(
           );
         }
         // eslint-disable-next-line no-await-in-loop
-        await sleep(POLLING_TIME);
+        await sleep(EXTENDED_POLLING_TIME);
       } catch (e) {
         console.error('Failed to check import status', e);
         throw e;

--- a/fwoa-tools/src/migrationUtils.ts
+++ b/fwoa-tools/src/migrationUtils.ts
@@ -20,6 +20,7 @@ export async function sleep(milliseconds: number): Promise<unknown> {
 }
 
 export const POLLING_TIME: number = 5000;
+export const EXTENDED_POLLING_TIME: number = POLLING_TIME * 20;
 export const MS_TO_HOURS: number = 60 * 60 * 1000;
 export const HEALTHLAKE_BUNDLE_LIMIT: number = 160;
 export const EXPORT_STATE_FILE_NAME: string = 'migrationExport_Output.json';


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Import script needs extended polling time to prevent AHL throttling exception. 
Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Did you add new integration tests?
- [ ] Did you run integration tests with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
